### PR TITLE
Replaced copy.com link with a google drive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Once you have that you can get started:
 - (with Vagrant installed of course) execute `vagrant up`
 - Wait for the install to finish
 - Visit http://192.168.32.10/ in your browser and you should see a ColdFusion dump of the `server` scope
+- The default password for the coldfusion administrator is 'vagrant'.
 
 Customisation
 -------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ What you get
 Getting started
 ---------------
 
-Before anything else, you need to go and [grab the ColdFusion 10 installer file](https://www.copy.com/s/nhIbHZYZnmPN/ColdFusion%20Repo/10.0.0/ColdFusion_10_WWEJ_linux64.bin):
+Before anything else, you need to go and [grab the ColdFusion 10 installer file](https://e05ac1a30afa93e642cc134035af0ab2babf7ac5.googledrive.com/host/0B-P1-Q_5RyjoMHZ2ZEtieXZjZG8/AdobeColdFusion/10.0.0/ColdFusion_10_WWEJ_linux64.bin):
 
 Once you have that you can get started:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once you have that you can get started:
 - Copy the ColdFusion 1- installer file into `./chef/cookbooks/coldfusion10/files/default/`
 - (with Vagrant installed of course) execute `vagrant up`
 - Wait for the install to finish
-- Visit http://192.168.32.10/ in your browser and you should see a ColdFusion dump of the `server` scope
+- Visit http://192.168.99.10/ in your browser and you should see a ColdFusion dump of the `server` scope
 - The default password for the coldfusion administrator is 'vagrant'.
 
 Customisation


### PR DESCRIPTION
Copy was discontinued on May 1, 2016, so the link no longer works.  I replaced it with a link that I found on http://www.cfmlrepo.com/.
